### PR TITLE
Bug-Fix: Machine Crossover and Moving

### DIFF
--- a/prodsys/optimization/optimization_util.py
+++ b/prodsys/optimization/optimization_util.py
@@ -103,7 +103,7 @@ def crossover(ind1, ind2):
     machines_2 = adapters.get_machines(adapter2)
     transport_resources_1 = adapters.get_transport_resources(adapter1)
     transport_resources_2 = adapters.get_transport_resources(adapter2)
-    if "machine " in crossover_type:
+    if "machine" in crossover_type:
         adapter1.resource_data = transport_resources_1
         adapter2.resource_data = transport_resources_2
         if crossover_type == "partial_machine":

--- a/prodsys/optimization/optimization_util.py
+++ b/prodsys/optimization/optimization_util.py
@@ -441,14 +441,14 @@ def move_machine(adapter_object: adapters.ProductionSystemAdapter) -> bool:
     possible_machines = adapters.get_machines(adapter_object)
     if not possible_machines:
         return False
-    machine = random.choice(possible_machines)
+    moved_machine = random.choice(possible_machines)
     possible_positions = deepcopy(adapter_object.scenario_data.options.positions)
-    for machine in adapter_object.resource_data:
+    for machine in possible_machines:
         if machine.location in possible_positions:
             possible_positions.remove(machine.location)
     if not possible_positions:
         return False
-    machine.location = random.choice(possible_positions)
+    moved_machine.location = random.choice(possible_positions)
     return True
 
 


### PR DESCRIPTION
Two bugs in the mutation and crossover used for the evolutionary algorithm were identified leading to crossover only being performed on transport resources and move_machines only relocating the last transport resource.