### PR TITLE
Bug Fix: Machine-Crossover and Move Machine fixed for evolutionary algorithm

### DIFF
--- a/prodsys/optimization/optimization_util.py
+++ b/prodsys/optimization/optimization_util.py
@@ -107,7 +107,7 @@ def crossover(ind1, ind2):
         adapter1.resource_data = transport_resources_1
         adapter2.resource_data = transport_resources_2
         if crossover_type == "partial_machine":
-            min_length = max(len(machines_1, machines_2))
+            min_length = min(len(machines_1),len(machines_2))
             machines_1 = machines_1[:min_length] + machines_2[min_length:]
             machines_2 = machines_2[:min_length] + machines_1[min_length:]
         adapter1.resource_data += machines_2

--- a/prodsys/optimization/optimization_util.py
+++ b/prodsys/optimization/optimization_util.py
@@ -103,7 +103,7 @@ def crossover(ind1, ind2):
     machines_2 = adapters.get_machines(adapter2)
     transport_resources_1 = adapters.get_transport_resources(adapter1)
     transport_resources_2 = adapters.get_transport_resources(adapter2)
-    if "machine " in crossover_type:
+    if "machine" in crossover_type:
         adapter1.resource_data = transport_resources_1
         adapter2.resource_data = transport_resources_2
         if crossover_type == "partial_machine":

--- a/prodsys/optimization/optimization_util.py
+++ b/prodsys/optimization/optimization_util.py
@@ -441,14 +441,14 @@ def move_machine(adapter_object: adapters.ProductionSystemAdapter) -> bool:
     possible_machines = adapters.get_machines(adapter_object)
     if not possible_machines:
         return False
-    machine = random.choice(possible_machines)
+    moved_machine = random.choice(possible_machines)
     possible_positions = deepcopy(adapter_object.scenario_data.options.positions)
-    for machine in adapter_object.resource_data:
+    for machine in possible_machines:
         if machine.location in possible_positions:
             possible_positions.remove(machine.location)
     if not possible_positions:
         return False
-    machine.location = random.choice(possible_positions)
+    moved_machine.location = random.choice(possible_positions)
     return True
 
 


### PR DESCRIPTION
1. Condition for crossover between machines was never met. Small fix in partial_machine crossover to work.
2. Looping with variable named "machine" over the resource_data in move_machine function resulted in the last resource_data (a transport_resource) being the one which is moved. 