### PR TITLE
Add new transport control policies: Nearest_Origin_and_longest_target_queues_transport and Nearest_Origin_and_shortest_target_input_queues_transport

### DIFF
--- a/prodsys/factories/resource_factory.py
+++ b/prodsys/factories/resource_factory.py
@@ -35,6 +35,9 @@ CONTROL_POLICY_DICT: Dict = {
     ResourceControlPolicy.LIFO: control.LIFO_control_policy,
     ResourceControlPolicy.SPT: control.SPT_control_policy,
     TransportControlPolicy.SPT_transport: control.SPT_transport_control_policy,
+    TransportControlPolicy.Nearest_origin_and_longest_target_queues_transport : control.Nearest_origin_and_longest_target_queues_transport_control_policy,
+    TransportControlPolicy.Nearest_origin_and_shortest_target_input_queues_transport : control.Nearest_origin_and_shortest_target_input_queues_transport_control_policy,
+
 }
 
 

--- a/prodsys/factories/resource_factory.py
+++ b/prodsys/factories/resource_factory.py
@@ -35,8 +35,8 @@ CONTROL_POLICY_DICT: Dict = {
     ResourceControlPolicy.LIFO: control.LIFO_control_policy,
     ResourceControlPolicy.SPT: control.SPT_control_policy,
     TransportControlPolicy.SPT_transport: control.SPT_transport_control_policy,
-    TransportControlPolicy.Nearest_origin_and_longest_target_queues_transport : control.Nearest_origin_and_longest_target_queues_transport_control_policy,
-    TransportControlPolicy.Nearest_origin_and_shortest_target_input_queues_transport : control.Nearest_origin_and_shortest_target_input_queues_transport_control_policy,
+    TransportControlPolicy.NEAREST_ORIGIN_AND_LONGEST_TARGET_QUEUES_TRANSPORT : control.nearest_origin_and_longest_target_queues_transport_control_policy,
+    TransportControlPolicy.NEAREST_ORIGIN_AND_SHORTEST_TARGET_INPUT_QUEUES_TRANSPORT : control.nearest_origin_and_shortest_target_input_queues_transport_control_policy,
 
 }
 

--- a/prodsys/models/resource_data.py
+++ b/prodsys/models/resource_data.py
@@ -49,10 +49,13 @@ class TransportControlPolicy(str, Enum):
 
     - FIFO: First in first out.
     - SPT_transport: Shortest transport time first.
+    - SPT_transport: Shortest raw transport time first. Does not consider distance to start of the transport.
+    - Nearest_origin_and_longest_target_queues_transport: Nearest_Origin but also sorts by the length of the target queue to make sure, something can be picked up at the target.
     """
 
     FIFO = "FIFO"
     SPT_transport = "SPT_transport"
+    Nearest_origin_and_longest_target_queues_transport = "Nearest_origin_and_longest_target_queues_transport"
 
 
 class ResourceData(CoreAsset):

--- a/prodsys/models/resource_data.py
+++ b/prodsys/models/resource_data.py
@@ -48,16 +48,15 @@ class TransportControlPolicy(str, Enum):
     Enum that represents the control policy of a transport resource.
 
     - FIFO: First in first out.
-    - SPT_transport: Shortest transport time first.
     - SPT_transport: Shortest raw transport time first. Does not consider distance to start of the transport.
-    - Nearest_origin_and_longest_target_queues_transport: Nearest_Origin but also sorts by the length of the target queue to make sure, something can be picked up at the target.
-    - Nearest_origin_and_shortest_target_input_queues_transport: Nearest_Origin but also sorts by the length of the target input queue to prefer target machines, that have lower number of products waiting to be processed.
+    - NEAREST_ORIGIN_AND_LONGEST_TARGET_QUEUES_TRANSPORT: Nearest_Origin but also sorts by the length of the target queue to make sure, something can be picked up at the target.
+    - NEAREST_ORIGIN_AND_SHORTEST_TARGET_INPUT_QUEUES_TRANSPORT: Nearest_Origin but also sorts by the length of the target input queue to prefer target machines, that have lower number of products waiting to be processed.
     """
 
     FIFO = "FIFO"
     SPT_transport = "SPT_transport"
-    Nearest_origin_and_longest_target_queues_transport = "Nearest_origin_and_longest_target_queues_transport"
-    Nearest_origin_and_shortest_target_input_queues_transport = "Nearest_origin_and_shortest_target_input_queues_transport"
+    NEAREST_ORIGIN_AND_LONGEST_TARGET_QUEUES_TRANSPORT = "Nearest_origin_and_longest_target_queues_transport"
+    NEAREST_ORIGIN_AND_SHORTEST_TARGET_INPUT_QUEUES_TRANSPORT = "Nearest_origin_and_shortest_target_input_queues_transport"
 
 
 class ResourceData(CoreAsset):

--- a/prodsys/models/resource_data.py
+++ b/prodsys/models/resource_data.py
@@ -51,11 +51,13 @@ class TransportControlPolicy(str, Enum):
     - SPT_transport: Shortest transport time first.
     - SPT_transport: Shortest raw transport time first. Does not consider distance to start of the transport.
     - Nearest_origin_and_longest_target_queues_transport: Nearest_Origin but also sorts by the length of the target queue to make sure, something can be picked up at the target.
+    - Nearest_origin_and_shortest_target_input_queues_transport: Nearest_Origin but also sorts by the length of the target input queue to prefer target machines, that have lower number of products waiting to be processed.
     """
 
     FIFO = "FIFO"
     SPT_transport = "SPT_transport"
     Nearest_origin_and_longest_target_queues_transport = "Nearest_origin_and_longest_target_queues_transport"
+    Nearest_origin_and_shortest_target_input_queues_transport = "Nearest_origin_and_shortest_target_input_queues_transport"
 
 
 class ResourceData(CoreAsset):

--- a/prodsys/models/scenario_data.py
+++ b/prodsys/models/scenario_data.py
@@ -82,7 +82,7 @@ class ScenarioOptionsData(BaseModel):
     Args:
         transformations (List[ReconfigurationEnum]): List of possible transformations of the configuration.
         machine_controllers (List[Literal["FIFO", "LIFO", "SPT"]]): List of possible controllers for machines.
-        transport_controllers (List[Literal["FIFO", "SPT_transport"]]): List of possible controllers for transport resources.
+        transport_controllers (List[Literal["FIFO", "SPT_transport", "Nearest_origin_and_longest_target_queues_transport", "Nearest_origin_and_shortest_target_input_queues_transport"]]): List of possible controllers for transport resources.
         routing_heuristics (List[Literal["shortest_queue", "random", "FIFO"]]): List of possible routing heuristics for sources.
         positions (List[conlist(float, min_items=2, max_items=2)]): List of possible positions for machines in the layout.
 

--- a/prodsys/simulation/control.py
+++ b/prodsys/simulation/control.py
@@ -558,7 +558,7 @@ def SPT_transport_control_policy(requests: List[request.TransportResquest]) -> N
             x.origin.get_location(), x.target.get_location()
         )
     )
-def Nearest_origin_and_longest_target_queues_transport_control_policy(requests: List[request.TransportResquest]) -> None:
+def nearest_origin_and_longest_target_queues_transport_control_policy(requests: List[request.TransportResquest]) -> None:
     """
     Sort the requests according to nearest origin without considering the target location. 
     Second order sorting by descending length of the target output queues, to prefer targets where a product can be picked up.
@@ -569,12 +569,14 @@ def Nearest_origin_and_longest_target_queues_transport_control_policy(requests: 
         key=lambda x: (
             x.process.get_expected_process_time(
                 x.resource.data.location, x.origin.get_location()),
-                - x.target.get_output_queue_length())
+                - x.target.get_output_queue_length()
+                )
     )
-def Nearest_origin_and_shortest_target_input_queues_transport_control_policy(requests: List[request.TransportResquest]) -> None:
+
+def nearest_origin_and_shortest_target_input_queues_transport_control_policy(requests: List[request.TransportResquest]) -> None:
     """
     Sort the requests according to nearest origin without considering the target location.
-    Second order sorting by ascending length of the target input queue.
+    Second order sorting by ascending length of the target input queue so that resources with empty input queues get material to process.
 
     Args:
         requests (List[request.TransportResquest]): The list of requests.
@@ -583,7 +585,8 @@ def Nearest_origin_and_shortest_target_input_queues_transport_control_policy(req
         key=lambda x: (
             x.process.get_expected_process_time(
                 x.resource.data.location, x.origin.get_location()),
-                sum([len(q.items) for q in x.target.input_queues]))
+            x.target.get_input_queue_length()
+            )
     )
 
 def agent_control_policy(

--- a/prodsys/simulation/control.py
+++ b/prodsys/simulation/control.py
@@ -560,7 +560,8 @@ def SPT_transport_control_policy(requests: List[request.TransportResquest]) -> N
     )
 def Nearest_origin_and_longest_target_queues_transport_control_policy(requests: List[request.TransportResquest]) -> None:
     """
-    Sort the requests according to nearest origin without considering the target.
+    Sort the requests according to nearest origin without considering the target location. 
+    Second order sorting by descending length of the target output queues, to prefer targets where a product can be picked up.
     Args:
         requests (List[request.TransportResquest]): The list of requests.
     """
@@ -569,6 +570,20 @@ def Nearest_origin_and_longest_target_queues_transport_control_policy(requests: 
             x.process.get_expected_process_time(
                 x.resource.data.location, x.origin.get_location()),
                 - x.target.get_output_queue_length())
+    )
+def Nearest_origin_and_shortest_target_input_queues_transport_control_policy(requests: List[request.TransportResquest]) -> None:
+    """
+    Sort the requests according to nearest origin without considering the target location.
+    Second order sorting by ascending length of the target input queue.
+
+    Args:
+        requests (List[request.TransportResquest]): The list of requests.
+    """
+    requests.sort(
+        key=lambda x: (
+            x.process.get_expected_process_time(
+                x.resource.data.location, x.origin.get_location()),
+                sum([len(q.items) for q in x.target.input_queues]))
     )
 
 def agent_control_policy(

--- a/prodsys/simulation/control.py
+++ b/prodsys/simulation/control.py
@@ -558,7 +558,18 @@ def SPT_transport_control_policy(requests: List[request.TransportResquest]) -> N
             x.origin.get_location(), x.target.get_location()
         )
     )
-
+def Nearest_origin_and_longest_target_queues_transport_control_policy(requests: List[request.TransportResquest]) -> None:
+    """
+    Sort the requests according to nearest origin without considering the target.
+    Args:
+        requests (List[request.TransportResquest]): The list of requests.
+    """
+    requests.sort(
+        key=lambda x: (
+            x.process.get_expected_process_time(
+                x.resource.data.location, x.origin.get_location()),
+                - x.target.get_output_queue_length())
+    )
 
 def agent_control_policy(
     gym_env: sequencing_control_env.AbstractSequencingControlEnv, requests: List[request.Request]

--- a/prodsys/simulation/resources.py
+++ b/prodsys/simulation/resources.py
@@ -243,6 +243,14 @@ class Resource(BaseModel, ABC, resource.Resource):
         """
         return self.data.location
 
+    def get_output_queue_length(self) -> List[float]:
+        """
+        Returns total number of items in all output_queues.
+        Returns:
+            int: Sum of items in the resources output-queues.
+        """
+        return sum([len(q.items) for q in self.output_queues])
+
     def set_location(self, new_location: List[float]) -> None:
         """
         Sets the location of the resource.

--- a/prodsys/simulation/resources.py
+++ b/prodsys/simulation/resources.py
@@ -242,10 +242,21 @@ class Resource(BaseModel, ABC, resource.Resource):
             List[float]: The location of the resource. Has to have length 2.
         """
         return self.data.location
+    
 
-    def get_output_queue_length(self) -> List[float]:
+    def get_input_queue_length(self) -> int:
+        """
+        Returns total number of items in all input_queues.
+
+        Returns:
+            int: Sum of items in the resources input-queues.
+        """
+        return sum([len(q.items) for q in self.input_queues])
+
+    def get_output_queue_length(self) -> int:
         """
         Returns total number of items in all output_queues.
+        
         Returns:
             int: Sum of items in the resources output-queues.
         """

--- a/prodsys/simulation/router.py
+++ b/prodsys/simulation/router.py
@@ -195,7 +195,8 @@ def shortest_queue_routing_heuristic(
         possible_resources (List[resources.Resource]): A list of possible resources.
     """
     if any(not isinstance(resource, resources.ProductionResource) for resource in possible_resources):
-        random_routing_heuristic(possible_resources)
+        np.random.shuffle(possible_resources)
+        possible_resources.sort(key=lambda x: len(x.get_controller().requests))
         return
     np.random.shuffle(possible_resources)
     possible_resources.sort(key=lambda x: sum([len(q.items) for q in x.input_queues]))

--- a/prodsys/simulation/sink.py
+++ b/prodsys/simulation/sink.py
@@ -47,13 +47,23 @@ class Sink(BaseModel):
         """
         return self.data.location
 
-    def get_output_queue_length(self) -> List[float]:
+    def get_input_queue_length(self) -> int:
+        """
+        Returns total number of items in all input_queues. Defaults to 0 for a sink.
+
+        Returns:
+            int(0)
+        """
+        return 0
+
+    def get_output_queue_length(self) -> int:
         """
         Returns zero. Needed for transport control policies that use the target locations output queue for request ordering.
         Returns:
             int(0)
         """
         return 0
+    
     def register_finished_product(self, product: product.Product):
         """
         Registers a finished product when it reaches the sink.

--- a/prodsys/simulation/sink.py
+++ b/prodsys/simulation/sink.py
@@ -46,7 +46,14 @@ class Sink(BaseModel):
             List[float]: The location. Has to be a list of length 2.
         """
         return self.data.location
-    
+
+    def get_output_queue_length(self) -> List[float]:
+        """
+        Returns zero. Needed for transport control policies that use the target locations output queue for request ordering.
+        Returns:
+            int(0)
+        """
+        return 0
     def register_finished_product(self, product: product.Product):
         """
         Registers a finished product when it reaches the sink.

--- a/prodsys/simulation/source.py
+++ b/prodsys/simulation/source.py
@@ -54,6 +54,25 @@ class Source(BaseModel):
         """
         self.env.process(self.create_product_loop())
 
+    def get_output_queue_length(self) -> int:
+        """
+        Returns total number of items in all output_queues.
+
+        Returns:
+            int: Sum of items in the source output-queues.
+        """
+        return sum([len(q.items) for q in self.output_queues])
+
+
+    def get_input_queue_length(self) -> int:
+        """
+        Returns total number of items in all input_queues.
+
+        Returns:
+            int(0)
+        """
+        return 0
+
     def create_product_loop(self) -> Generator:
         """
         Simpy process that creates products and puts them in the output queues.


### PR DESCRIPTION
Transport Control policies currently dont take the distance needed to travel to the origin (pickup) location into consideration. SPT transport minimizes the distance travelled while transporting a product. Thereby, very distant origins that need a short transport are preferred over nearby origin locations, that require a longer transport. However, minimizing empty transport should be minimized, so the latter should be preferred, which the nearest_origin preference does. 

The "longest_target_queue" part creates a preference of transports that lead to a location, where a finished product can be picked up. So the nearest origin is the current location of the transport resource. Thereby, if the closest origin has been found and there are multiple products that require transportation, the product that leads to a non-empty target output queue is preferred.